### PR TITLE
Simplify registering data definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,18 @@ namespace FsConnectTest
         public static void Main()
         {
             FsConnect fsConnect = new FsConnect();
-            fsConnect.Connect("localhost", 500);
+            fsConnect.Connect("TestApp", "localhost", 500);
             fsConnect.FsDataReceived += HandleReceivedFsData;
 
             List<SimProperty> definition = new List<SimProperty>();
 
+            // Consult the SDK for valid sim variable names, units and whether they can be written to.
             definition.Add(new SimProperty("Title", null, SIMCONNECT_DATATYPE.STRING256));
             definition.Add(new SimProperty("Plane Latitude", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
             definition.Add(new SimProperty("Plane Longitude", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
-            definition.Add(new SimProperty("Plane Alt Above Ground", "feet", SIMCONNECT_DATATYPE.FLOAT64));
+            
+            // Can also use predefined enums for sim variables and units (incomplete)
+            definition.Add(new SimProperty(FsSimVar.PlaneAltitude, FsUnit.Feet, SIMCONNECT_DATATYPE.FLOAT64));
             definition.Add(new SimProperty("Plane Heading Degrees Gyro", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
 
             fsConnect.RegisterDataDefinition<PlaneInfoResponse>(Requests.PlaneInfo, definition);

--- a/README.md
+++ b/README.md
@@ -5,14 +5,22 @@ If, on the other hand, you just want to connect to Flight Simulator and read som
 FsConnect uses the _Microsoft.FlightSimulator.SimConnect_ .NET Framework library and the underlying native x64 _simconnect.dll_ library. 
 These files are distributed via the Flight Simulator 2020 SDK, currently version 0.5.1, but are included for easy use.
 
+At the moment this project is intended as an easier to use wrapper than the current SimConnect for simple projects, creating a simpler C# programming model and reducing the need for repeated boiler plate code. Expect breaking changes.
+
 ## Current features
 * Supports TCP connection, without use of SimConnect.cfg file
 * Supports registering and requesting simple simulation variables.
+* Supports updating simulation variables.
 * Does not require a Windows message pump.
 * NuGet package handles deployment of native binaries, just add reference to package.
 
 # Getting started
-* Download the Flight Simulator SDK and take a look at the Simvars sample project.
+* Download the Flight Simulator SDK.
+* See the list of available simulation variables in the SDK documentation: Documentation/04-Developer_Tools/SimConnect/SimConnect_Status_of_Simulation_Variables.html
+* Determine unit to use when registering the data structure.
+* Build a C# struct to hold data data definition. (See example below)
+* Define a data definition and register it. (See example below)
+* Take a look at the Simvars sample project and example below.
 
 # Usage
 
@@ -42,7 +50,7 @@ namespace FsConnectTest
         public String Title;
         public double Latitude;
         public double Longitude;
-        public double AltitudeAboveGround;
+        public double Altitude;
         public double Heading;
     }
 
@@ -63,7 +71,7 @@ namespace FsConnectTest
             
             // Can also use predefined enums for sim variables and units (incomplete)
             definition.Add(new SimProperty(FsSimVar.PlaneAltitude, FsUnit.Feet, SIMCONNECT_DATATYPE.FLOAT64));
-            definition.Add(new SimProperty("Plane Heading Degrees Gyro", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
+            definition.Add(new SimProperty(FsSimVar.PlaneHeadingDegreesTrue, FsUnit.Degrees, SIMCONNECT_DATATYPE.FLOAT64));
 
             fsConnect.RegisterDataDefinition<PlaneInfoResponse>(Requests.PlaneInfo, definition);
 
@@ -77,7 +85,7 @@ namespace FsConnectTest
             if (e.RequestId == (uint)Requests.PlaneInfo)
             {
                 PlaneInfoResponse r = (PlaneInfoResponse)e.Data;
-                Console.WriteLine($"{r.Latitude:F4} {r.Longitude:F4} {r.AltitudeAboveGround:F1} {r.Heading}");
+                Console.WriteLine($"{r.Latitude:F4} {r.Longitude:F4} {r.Altitude:F1} {r.Heading}");
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 A simple easy-to-use wrapper for the Flight Simulator 2020 SimConnect library. A simple solution to simple problems, if you already are fluent in SimConnect, this won't impress you much.
 If, on the other hand, you just want to connect to Flight Simulator and read some information this may give you a quicker start.
 
+FsConnect uses the _Microsoft.FlightSimulator.SimConnect_ .NET Framework library and the underlying native x64 _simconnect.dll_ library. 
+These files are distributed via the Flight Simulator 2020 SDK, currently version 0.5.1, but are included for easy use.
+
 ## Current features
 * Supports TCP connection, without use of SimConnect.cfg file
 * Supports registering and requesting simple simulation variables.
 * Does not require a Windows message pump.
+* NuGet package handles deployment of native binaries, just add reference to package.
 
 # Getting started
 * Download the Flight Simulator SDK and take a look at the Simvars sample project.
@@ -50,13 +54,13 @@ namespace FsConnectTest
             fsConnect.Connect("localhost", 500);
             fsConnect.FsDataReceived += HandleReceivedFsData;
 
-            List<Tuple<string, string, SIMCONNECT_DATATYPE>> definition = new List<Tuple<string, string, SIMCONNECT_DATATYPE>>();
+            List<SimProperty> definition = new List<SimProperty>();
 
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("Title", null, SIMCONNECT_DATATYPE.STRING256));
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("Plane Latitude", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("Plane Longitude", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("Plane Alt Above Ground", "feet", SIMCONNECT_DATATYPE.FLOAT64));
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("Plane Heading Degrees Gyro", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
+            definition.Add(new SimProperty("Title", null, SIMCONNECT_DATATYPE.STRING256));
+            definition.Add(new SimProperty("Plane Latitude", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
+            definition.Add(new SimProperty("Plane Longitude", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
+            definition.Add(new SimProperty("Plane Alt Above Ground", "feet", SIMCONNECT_DATATYPE.FLOAT64));
+            definition.Add(new SimProperty("Plane Heading Degrees Gyro", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
 
             fsConnect.RegisterDataDefinition<PlaneInfoResponse>(Requests.PlaneInfo, definition);
 

--- a/src/CTrue.FsConnect.TestConsole/Program.cs
+++ b/src/CTrue.FsConnect.TestConsole/Program.cs
@@ -64,6 +64,7 @@ namespace CTrue.FsConnect.TestConsole
                 _keyHandlers.Add(ConsoleKey.F, DecreaseAltitude);
 
                 Console.WriteLine("Press any key to request data from Flight Simulator or ESC to quit.");
+                Console.WriteLine("Press WASD keys to move, Q and E to rotate, R and F to change altitude.");
                 ConsoleKeyInfo cki = Console.ReadKey(true);
 
                 _fsConnect.SetText("Test Console connected", 2);
@@ -151,12 +152,6 @@ namespace CTrue.FsConnect.TestConsole
         private static void PollFlightSimulator()
         {
             _fsConnect.RequestData(Requests.PlaneInfo);
-        }
-
-        private static void UpdateFlightSimulator()
-        {
-            _planeInfoResponse.Latitude += _deltaLatitude;
-            _fsConnect.UpdateData(Definitions.PlaneInfo, _planeInfoResponse);
         }
 
         private static void InitializeDataDefinitions(FsConnect fsConnect)

--- a/src/CTrue.FsConnect.TestConsole/Program.cs
+++ b/src/CTrue.FsConnect.TestConsole/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using CommandLine;
 using CommandLine.Text;
 using Microsoft.FlightSimulator.SimConnect;
@@ -11,6 +12,15 @@ namespace CTrue.FsConnect.TestConsole
     /// </summary>
     class Program
     {
+        private static FsConnect _fsConnect;
+        private static Dictionary<ConsoleKey, Action> _keyHandlers = new Dictionary<ConsoleKey, Action>();
+        private static PlaneInfoResponse _planeInfoResponse;
+
+        private static double _deltaLatitude = 0.001;
+        private static double _deltaLongitude = 0.001;
+        private static double _deltaAltitude = 1000;
+        private static double _deltaHeading = 10;
+
         static void Main(string[] args)
         {
             CommandLine.Parser parser = new CommandLine.Parser(with => with.HelpWriter = null);
@@ -25,12 +35,12 @@ namespace CTrue.FsConnect.TestConsole
         {
             try
             {
-                FsConnect fsConnect = new FsConnect();
+                _fsConnect = new FsConnect();
 
                 Console.WriteLine($"Connecting to Flight Simulator on {commandLineOptions.Hostname}:{commandLineOptions.Port}");
                 try
                 {
-                    fsConnect.Connect(commandLineOptions.Hostname, commandLineOptions.Port);
+                    _fsConnect.Connect("FsConnectTestConsole", commandLineOptions.Hostname, commandLineOptions.Port);
                 }
                 catch (Exception e)
                 {
@@ -38,24 +48,50 @@ namespace CTrue.FsConnect.TestConsole
                     return;
                 }
             
-                fsConnect.FsDataReceived += HandleReceivedFsData;
-
+                _fsConnect.FsDataReceived += HandleReceivedFsData;
+                
                 Console.WriteLine("Initializing data definitions");
-                InitializeDataDefinitions(fsConnect);
+                InitializeDataDefinitions(_fsConnect);
 
-                Console.WriteLine("Press any key to request data from Flight Simulator or Q to quit.");
+                _keyHandlers.Add(ConsoleKey.P, PollFlightSimulator);
+                _keyHandlers.Add(ConsoleKey.W, MoveForward);
+                _keyHandlers.Add(ConsoleKey.S, MoveBackward);
+                _keyHandlers.Add(ConsoleKey.A, MoveLeft);
+                _keyHandlers.Add(ConsoleKey.D, MoveRight);
+                _keyHandlers.Add(ConsoleKey.Q, RotateLeft);
+                _keyHandlers.Add(ConsoleKey.E, RotateRight);
+                _keyHandlers.Add(ConsoleKey.R, IncreaseAltitude);
+                _keyHandlers.Add(ConsoleKey.F, DecreaseAltitude);
+
+                Console.WriteLine("Press any key to request data from Flight Simulator or ESC to quit.");
                 ConsoleKeyInfo cki = Console.ReadKey(true);
 
-                while (cki.Key != ConsoleKey.Q)
+                _fsConnect.SetText("Test Console connected", 2);
+
+                _fsConnect.RequestData(Requests.PlaneInfo);
+
+                while (cki.Key != ConsoleKey.Escape)
                 {
-                    fsConnect.RequestData(Requests.PlaneInfo);
-                    
+                    if(_keyHandlers.ContainsKey(cki.Key))
+                    {
+                        _keyHandlers[cki.Key].Invoke();
+                    }
+                    else
+                    {
+                        PollFlightSimulator();
+                    }
+
                     cki = Console.ReadKey(true);
                 }
 
+                Console.ReadKey(true);
+
                 Console.WriteLine("Disconnecting from Flight Simulator");
-                fsConnect.Disconnect();
-                
+                _fsConnect.SetText("Test Console disconnecting", 1);
+                _fsConnect.Disconnect();
+                _fsConnect.Dispose();
+                _fsConnect = null;
+
                 Console.WriteLine("Done");
             }
             catch (Exception e)
@@ -64,18 +100,77 @@ namespace CTrue.FsConnect.TestConsole
             }
         }
 
+        private static void IncreaseAltitude()
+        {
+            _planeInfoResponse.Altitude += _deltaAltitude;
+            _fsConnect.UpdateData(Definitions.PlaneInfo, _planeInfoResponse);
+        }
+
+        private static void DecreaseAltitude()
+        {
+            _planeInfoResponse.Altitude -= _deltaAltitude;
+            _fsConnect.UpdateData(Definitions.PlaneInfo, _planeInfoResponse);
+        }
+
+        private static void RotateRight()
+        {
+            _planeInfoResponse.Heading += FsUtils.Deg2Rad(_deltaHeading);
+            _fsConnect.UpdateData(Definitions.PlaneInfo, _planeInfoResponse);
+        }
+
+        private static void RotateLeft()
+        {
+            _planeInfoResponse.Heading -= FsUtils.Deg2Rad(_deltaHeading);
+            _fsConnect.UpdateData(Definitions.PlaneInfo, _planeInfoResponse);
+        }
+
+        private static void MoveRight()
+        {
+            _planeInfoResponse.Longitude += _deltaLongitude;
+            _fsConnect.UpdateData(Definitions.PlaneInfo, _planeInfoResponse);
+        }
+
+        private static void MoveLeft()
+        {
+            _planeInfoResponse.Longitude -= _deltaLongitude;
+            _fsConnect.UpdateData(Definitions.PlaneInfo, _planeInfoResponse);
+        }
+
+        private static void MoveBackward()
+        {
+            _planeInfoResponse.Latitude -= _deltaLatitude;
+            _fsConnect.UpdateData(Definitions.PlaneInfo, _planeInfoResponse);
+        }
+
+        private static void MoveForward()
+        {
+            _planeInfoResponse.Latitude += _deltaLatitude;
+            _fsConnect.UpdateData(Definitions.PlaneInfo, _planeInfoResponse);
+        }
+
+        private static void PollFlightSimulator()
+        {
+            _fsConnect.RequestData(Requests.PlaneInfo);
+        }
+
+        private static void UpdateFlightSimulator()
+        {
+            _planeInfoResponse.Latitude += _deltaLatitude;
+            _fsConnect.UpdateData(Definitions.PlaneInfo, _planeInfoResponse);
+        }
+
         private static void InitializeDataDefinitions(FsConnect fsConnect)
         {
-            List<Tuple<string, string, SIMCONNECT_DATATYPE>> definition = new List<Tuple<string, string, SIMCONNECT_DATATYPE>>();
+            List<SimProperty> definition = new List<SimProperty>();
 
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("Title", null, SIMCONNECT_DATATYPE.STRING256));
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("Plane Latitude", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("Plane Longitude", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("Plane Alt Above Ground", "feet", SIMCONNECT_DATATYPE.FLOAT64));
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("PLANE ALTITUDE", "feet", SIMCONNECT_DATATYPE.FLOAT64));
-            definition.Add(new Tuple<string, string, SIMCONNECT_DATATYPE>("Plane Heading Degrees Gyro", "degrees", SIMCONNECT_DATATYPE.FLOAT64));
+            definition.Add(new SimProperty(FsSimVar.Title, FsUnit.None, SIMCONNECT_DATATYPE.STRING256));
+            definition.Add(new SimProperty(FsSimVar.PlaneLatitude, FsUnit.Radians, SIMCONNECT_DATATYPE.FLOAT64));
+            definition.Add(new SimProperty(FsSimVar.PlaneLongitude, FsUnit.Radians, SIMCONNECT_DATATYPE.FLOAT64));
+            definition.Add(new SimProperty(FsSimVar.PlaneAltitudeAboveGround, FsUnit.Feet, SIMCONNECT_DATATYPE.FLOAT64));
+            definition.Add(new SimProperty(FsSimVar.PlaneAltitude, FsUnit.Feet, SIMCONNECT_DATATYPE.FLOAT64));
+            definition.Add(new SimProperty(FsSimVar.PlaneHeadingDegreesTrue, FsUnit.Radians, SIMCONNECT_DATATYPE.FLOAT64));
 
-            fsConnect.RegisterDataDefinition<PlaneInfoResponse>(Requests.PlaneInfo, definition);
+            fsConnect.RegisterDataDefinition<PlaneInfoResponse>(Definitions.PlaneInfo, definition);
         }
 
         private static void HandleReceivedFsData(object sender, FsDataReceivedEventArgs e)
@@ -84,9 +179,9 @@ namespace CTrue.FsConnect.TestConsole
             {
                 if(e.RequestId == (uint)Requests.PlaneInfo)
                 {
-                    PlaneInfoResponse r = (PlaneInfoResponse)e.Data;
+                    _planeInfoResponse = (PlaneInfoResponse)e.Data;
 
-                    Console.WriteLine($"Pos: ({r.Latitude:F4}, {r.Longitude:F4}), Alt: {r.Altitude:F0} ft, Hdg: {r.Heading:F1} deg");
+                    Console.WriteLine($"Pos: ({FsUtils.Rad2Deg(_planeInfoResponse.Latitude):F4}, {FsUtils.Rad2Deg(_planeInfoResponse.Longitude):F4}), Alt: {_planeInfoResponse.Altitude:F0} ft, Hdg: {FsUtils.Rad2Deg(_planeInfoResponse.Heading):F1} deg");
                 }
             }
             catch (Exception ex)

--- a/src/CTrue.FsConnect.TestConsole/Requests.cs
+++ b/src/CTrue.FsConnect.TestConsole/Requests.cs
@@ -4,4 +4,9 @@
     {
         PlaneInfo=0
     }
+
+    public enum Definitions
+    {
+        PlaneInfo=0
+    }
 }

--- a/src/CTrue.FsConnect/CTrue.FsConnect.csproj
+++ b/src/CTrue.FsConnect/CTrue.FsConnect.csproj
@@ -13,8 +13,16 @@ Contains SimConnect binaries, as distributed by the Flight Simulator 20202 SDK 0
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/c-true/FsConnect</RepositoryUrl>
     <PackageTags>msfs flight-simulator simconnect</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CTrue.FsConnect/CTrue.FsConnect.csproj
+++ b/src/CTrue.FsConnect/CTrue.FsConnect.csproj
@@ -15,6 +15,8 @@ Contains SimConnect binaries, as distributed by the Flight Simulator 20202 SDK 0
     <PackageTags>msfs flight-simulator simconnect</PackageTags>
     <Version>1.0.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReleaseNotes>Simplified registering data definitions.
+Added support for updating data structures.</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/CTrue.FsConnect/FsDataReceivedEventArgs.cs
+++ b/src/CTrue.FsConnect/FsDataReceivedEventArgs.cs
@@ -2,10 +2,19 @@
 
 namespace CTrue.FsConnect
 {
+    /// <summary>
+    /// Used to hold data received from Flight Simulator.
+    /// </summary>
     public class FsDataReceivedEventArgs : EventArgs
     {
+        /// <summary>
+        /// The request id of the received data.
+        /// </summary>
         public uint RequestId { get; set; }
         
+        /// <summary>
+        /// The data that was received.
+        /// </summary>
         public object Data { get; set; }
     }
 }

--- a/src/CTrue.FsConnect/FsSimVar.cs
+++ b/src/CTrue.FsConnect/FsSimVar.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+
+namespace CTrue.FsConnect
+{
+    public enum FsSimVar
+    {
+        Title,
+        PlaneLatitude,
+        PlaneLongitude,
+        PlaneAltitudeAboveGround,
+        PlaneAltitude,
+        PlaneHeadingDegreesTrue,
+        GpsGroundSpeed
+    }
+
+    public static class FsSimVarFactory
+    {
+        private static Dictionary<FsSimVar, string> _enumToCodeDictionary = new Dictionary<FsSimVar, string>();
+
+        static FsSimVarFactory()
+        {
+            _enumToCodeDictionary.Add(FsSimVar.Title, "TITLE");
+            _enumToCodeDictionary.Add(FsSimVar.PlaneLatitude, "PLANE LATITUDE");
+            _enumToCodeDictionary.Add(FsSimVar.PlaneLongitude, "PLANE LONGITUDE");
+            _enumToCodeDictionary.Add(FsSimVar.PlaneAltitudeAboveGround, "PLANE ALT ABOVE GROUND");
+            _enumToCodeDictionary.Add(FsSimVar.PlaneAltitude, "PLANE ALTITUDE");
+            _enumToCodeDictionary.Add(FsSimVar.PlaneHeadingDegreesTrue, "PLANE HEADING DEGREES TRUE");
+            _enumToCodeDictionary.Add(FsSimVar.GpsGroundSpeed, "GPS GROUND SPEED");
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="simvar"></param>
+        /// <returns></returns>
+        public static string GetSimVarCode(FsSimVar simVar)
+        {
+            return _enumToCodeDictionary[simVar];
+        }
+    }
+}

--- a/src/CTrue.FsConnect/FsUnit.cs
+++ b/src/CTrue.FsConnect/FsUnit.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+
+namespace CTrue.FsConnect
+{
+    public enum FsUnit
+    {
+        None,
+        Degrees,
+        Radians,
+        Feet,
+        Meter,
+        MeterPerSecond
+    }
+
+    public static class UnitFactory
+    {
+        private static Dictionary<FsUnit, string> _enumToCodeDictionary = new Dictionary<FsUnit, string>();
+
+        static UnitFactory()
+        {
+            _enumToCodeDictionary.Add(FsUnit.None, null);
+            _enumToCodeDictionary.Add(FsUnit.Degrees, "degrees");
+            _enumToCodeDictionary.Add(FsUnit.Radians, "radians");
+            _enumToCodeDictionary.Add(FsUnit.Feet, "feet");
+            _enumToCodeDictionary.Add(FsUnit.Meter, "meter");
+            _enumToCodeDictionary.Add(FsUnit.MeterPerSecond, "meter per second");
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="unit"></param>
+        /// <returns></returns>
+        public static string GetUnitCode(FsUnit unit)
+        {
+            return _enumToCodeDictionary[unit];
+        }
+    }
+}

--- a/src/CTrue.FsConnect/FsUtils.cs
+++ b/src/CTrue.FsConnect/FsUtils.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace CTrue.FsConnect
+{
+    /// <summary>
+    /// Utilities for handling Flight Simulator
+    /// </summary>
+    public class FsUtils
+    {
+        /// <summary>
+        /// Converts degrees to radians.
+        /// </summary>
+        /// <param name="deg"></param>
+        /// <returns></returns>
+        public static double Deg2Rad(double deg)
+        {
+            return deg * Math.PI / 180;
+        }
+
+        /// <summary>
+        /// Converts radians to degrees.
+        /// </summary>
+        public static double Rad2Deg(double rad)
+        {
+            return rad * 180 / Math.PI;
+        }
+    }
+}

--- a/src/CTrue.FsConnect/IFsConnect.cs
+++ b/src/CTrue.FsConnect/IFsConnect.cs
@@ -7,7 +7,10 @@ namespace CTrue.FsConnect
     /// <summary>
     /// A wrapper / helper class for connection to Flight Simulator.
     /// </summary>
-    public interface IFsConnect
+    /// <remarks>
+    /// This wrapper supports TCP IPv4 only, for the moment.
+    /// </remarks>
+    public interface IFsConnect : IDisposable
     {
         /// <summary>
         /// The <see cref="ConnectionChanged"/> event is raised when the connection status to Flight Simulator has changed.
@@ -32,13 +35,14 @@ namespace CTrue.FsConnect
         /// <summary>
         /// Connects to Flight Simulator on the specified host name and TCP port.
         /// </summary>
+        /// <param name="applicationName"></param>
         /// <param name="hostName"></param>
         /// <param name="port"></param>
         /// <remarks>
         /// A SimConnect.cfg file will be generated containing TCP connection information.
-        /// Flight Simulator must be configured for remote TCP connections.
+        /// Flight Simulator must be configured for remote TCP connections by editing the SimConnect.xml file that are part of the installation.
         /// </remarks>
-        void Connect(string hostName, uint port);
+        void Connect(string applicationName, string hostName, uint port);
 
         /// <summary>
         /// Disconnects from Flight Simulator.
@@ -56,6 +60,21 @@ namespace CTrue.FsConnect
         /// <remarks>
         /// A connection to Flight Simulator must have been established before registering data definitions.
         /// </remarks>
-        void RegisterDataDefinition<T>(Enum id, List<Tuple<string, string, SIMCONNECT_DATATYPE>> definition) where T : struct;
+        void RegisterDataDefinition<T>(Enum id, List<SimProperty> definition) where T : struct;
+
+        /// <summary>
+        /// Displays a text in Flight Simulator.
+        /// </summary>
+        /// <param name="text">The text to display.</param>
+        /// <param name="duration">Duration to display text, in seconds.</param>
+        void SetText(string text, int duration);
+
+        /// <summary>
+        /// Updated data.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="data"></param>
+        /// <typeparam name="T"></typeparam>
+        void UpdateData<T>(Enum id, T data);
     }
 }

--- a/src/CTrue.FsConnect/SimProperty.cs
+++ b/src/CTrue.FsConnect/SimProperty.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.FlightSimulator.SimConnect;
+
+namespace CTrue.FsConnect
+{
+    /// <summary>
+    /// The <see cref="SimProperty"/> class is used to define a data definition.
+    /// </summary>
+    public class SimProperty
+    {
+        /// <summary>
+        /// The name of the definition. See the SimVars class in the Simvars example in the SDK.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The unit of the definition. See the Units class in the Simvars example in the SDK.
+        /// </summary>
+        public string Unit { get; set; }
+
+        /// <summary>
+        /// The data type of the definition.
+        /// </summary>
+        public SIMCONNECT_DATATYPE DataType { get; set; }
+
+        /// <summary>
+        /// Creates an uninitialized instance of the <see cref="SimProperty"/> class.
+        /// </summary>
+        public SimProperty()
+        {
+        }
+
+        /// <summary>
+        /// Creates an initialized instance of the <see cref="SimProperty"/> class.
+        /// </summary>
+        public SimProperty(string name, string unit, SIMCONNECT_DATATYPE dataType)
+        {
+            Name = name;
+            Unit = unit;
+            DataType = dataType;
+        }
+
+        /// <summary>
+        /// Creates an initialized instance using enums for known values.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="unit"></param>
+        /// <param name="dataType"></param>
+        public SimProperty(FsSimVar simVar, FsUnit unit, SIMCONNECT_DATATYPE dataType)
+        {
+            Name = FsSimVarFactory.GetSimVarCode(simVar);
+            Unit = UnitFactory.GetUnitCode(unit);
+            DataType = dataType;
+        }
+    }
+}


### PR DESCRIPTION
**Summary of changes**

- Added SimVariable to hold metadata about simulation variables, used for registering data definitions.
- Added enums for a very few simulation variables and units.
- Support for updating simulation variables.
- Updated test console to demonstrate updating simulation variables