### PR TITLE
Fix #4 - Improved handling of SimConnect.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ A simple easy-to-use wrapper for the Flight Simulator 2020 SimConnect library. A
 If, on the other hand, you just want to connect to Flight Simulator and read some information this may give you a quicker start.
 
 FsConnect uses the _Microsoft.FlightSimulator.SimConnect_ .NET Framework library and the underlying native x64 _simconnect.dll_ library. 
-These files are distributed via the Flight Simulator 2020 SDK, currently version 0.5.1, but are included for easy use.
+These files are distributed via the Flight Simulator 2020 SDK, currently version 0.6.1, but are included for easy use.
 
 At the moment this project is intended as an easier to use wrapper than the current SimConnect for simple projects, creating a simpler C# programming model and reducing the need for repeated boiler plate code. Expect breaking changes.
 
 ## Current features
-* Supports TCP connection, without use of SimConnect.cfg file
+* Supports connections from API, without direct use of SimConnect.cfg file
 * Supports registering and requesting simple simulation variables.
 * Supports updating simulation variables.
 * Does not require a Windows message pump.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ namespace FsConnectTest
         public static void Main()
         {
             FsConnect fsConnect = new FsConnect();
+            
+            // Specify where the SimConnect.cfg should be written to
+            fsConnect.SimConnectFileLocation = SimConnectFileLocation.MyDocuments;
+            
+            // Creates a SimConnect.cfg and connect to Flight Simulator using this configuration.
             fsConnect.Connect("TestApp", "localhost", 500);
             fsConnect.FsDataReceived += HandleReceivedFsData;
 

--- a/src/CTrue.FsConnect.TestConsole/Options.cs
+++ b/src/CTrue.FsConnect.TestConsole/Options.cs
@@ -4,10 +4,13 @@ namespace CTrue.FsConnect.TestConsole
 {
     public class Options
     {
-        [Option('h', "hostname", Required = true, HelpText = "Sets the hostname of the host that is running Flight Simulator.")]
+        [Option('h', "hostname", SetName = "connect", HelpText = "Sets the hostname of the host that is running Flight Simulator.")]
         public string Hostname { get; set; }
 
-        [Option('p', "port", Required = true, HelpText = "Sets the TCP port that Flight Simulator is being hosting on.")]
+        [Option('p', "port", SetName = "connect", HelpText = "Sets the TCP port that Flight Simulator is being hosting on.")]
         public uint Port { get; set; }
+
+        [Option('i', "index", SetName = "config", HelpText = "Specifies the config index in SimConnect.cfg to use.")]
+        public uint ConfigIndex { get; set; }
     }
 }

--- a/src/CTrue.FsConnect.TestConsole/Program.cs
+++ b/src/CTrue.FsConnect.TestConsole/Program.cs
@@ -40,7 +40,7 @@ namespace CTrue.FsConnect.TestConsole
                 Console.WriteLine($"Connecting to Flight Simulator on {commandLineOptions.Hostname}:{commandLineOptions.Port}");
                 try
                 {
-                    _fsConnect.Connect("FsConnectTestConsole", commandLineOptions.Hostname, commandLineOptions.Port);
+                    _fsConnect.Connect("FsConnectTestConsole", commandLineOptions.Hostname, commandLineOptions.Port, SimConnectProtocol.Ipv4);
                 }
                 catch (Exception e)
                 {

--- a/src/CTrue.FsConnect.TestConsole/Program.cs
+++ b/src/CTrue.FsConnect.TestConsole/Program.cs
@@ -37,10 +37,20 @@ namespace CTrue.FsConnect.TestConsole
             {
                 _fsConnect = new FsConnect();
 
-                Console.WriteLine($"Connecting to Flight Simulator on {commandLineOptions.Hostname}:{commandLineOptions.Port}");
                 try
                 {
-                    _fsConnect.Connect("FsConnectTestConsole", commandLineOptions.Hostname, commandLineOptions.Port, SimConnectProtocol.Ipv4);
+                    if (string.IsNullOrEmpty(commandLineOptions.Hostname))
+                    {
+                        Console.WriteLine($"Connecting to Flight Simulator using index {commandLineOptions.ConfigIndex}");
+                        _fsConnect.Connect("FsConnectTestConsole", commandLineOptions.ConfigIndex);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Connecting to Flight Simulator on {commandLineOptions.Hostname}:{commandLineOptions.Port}");
+                        _fsConnect.Connect("FsConnectTestConsole", commandLineOptions.Hostname, commandLineOptions.Port, SimConnectProtocol.Ipv4);
+                    }
+
+
                 }
                 catch (Exception e)
                 {

--- a/src/CTrue.FsConnect.TestConsole/Properties/launchSettings.json
+++ b/src/CTrue.FsConnect.TestConsole/Properties/launchSettings.json
@@ -3,6 +3,14 @@
     "FsConnectTestConsole": {
       "commandName": "Project",
       "commandLineArgs": "-h 127.0.0.1 -p 500"
+    },
+    "FsConnectTestConsole1": {
+      "commandName": "Project",
+      "commandLineArgs": "-i 0"
+    },
+    "FsConnectTestConsole2": {
+      "commandName": "Project",
+      "commandLineArgs": ""
     }
   }
 }

--- a/src/CTrue.FsConnect.TestConsole/Properties/launchSettings.json
+++ b/src/CTrue.FsConnect.TestConsole/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "FsConnectTestConsole": {
       "commandName": "Project",
-      "commandLineArgs": "-h 192.168.1.174 -p 57490"
+      "commandLineArgs": "-h 127.0.0.1 -p 500"
     }
   }
 }

--- a/src/CTrue.FsConnect/CTrue.FsConnect.csproj
+++ b/src/CTrue.FsConnect/CTrue.FsConnect.csproj
@@ -6,7 +6,7 @@
     <Product>Flight Simulator Connect</Product>
     <Copyright />
     <Description>An easy to use wrapper for SimConnect, for connection to Flight Simulator 2020.
-Contains SimConnect binaries, as distributed by the Flight Simulator 20202 SDK 0.5.1 release.</Description>
+Contains SimConnect binaries, as distributed by the Flight Simulator 20202 SDK 0.6.0 release.</Description>
     <Authors>C-True</Authors>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
@@ -15,8 +15,7 @@ Contains SimConnect binaries, as distributed by the Flight Simulator 20202 SDK 0
     <PackageTags>msfs flight-simulator simconnect</PackageTags>
     <Version>1.0.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>Simplified registering data definitions.
-Added support for updating data structures.</PackageReleaseNotes>
+    <PackageReleaseNotes>Verified that dependencies are the same for the SDK 0.6.0 release.</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/CTrue.FsConnect/CTrue.FsConnect.csproj
+++ b/src/CTrue.FsConnect/CTrue.FsConnect.csproj
@@ -6,16 +6,19 @@
     <Product>Flight Simulator Connect</Product>
     <Copyright />
     <Description>An easy to use wrapper for SimConnect, for connection to Flight Simulator 2020.
-Contains SimConnect binaries, as distributed by the Flight Simulator 20202 SDK 0.6.0 release.</Description>
+Contains SimConnect binaries, as distributed by the Flight Simulator 20202 SDK 0.6.1 release.</Description>
     <Authors>C-True</Authors>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/c-true/FsConnect</RepositoryUrl>
     <PackageTags>msfs flight-simulator simconnect</PackageTags>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>Verified that dependencies are the same for the SDK 0.6.0 release.</PackageReleaseNotes>
+    <PackageReleaseNotes>Support for using predefined SimConnect.cfg or specifying location for where it should be written.
+Verified that dependencies are the same for the SDK 0.6.1 release.</PackageReleaseNotes>
+    <AssemblyVersion>1.0.3.0</AssemblyVersion>
+    <FileVersion>1.0.3.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/CTrue.FsConnect/FsConnect.cs
+++ b/src/CTrue.FsConnect/FsConnect.cs
@@ -55,11 +55,11 @@ namespace CTrue.FsConnect
         public event EventHandler<FsErrorEventArgs> FsError;
 
         /// <inheritdoc />
-        public void Connect(string applicationName)
+        public void Connect(string applicationName, uint configIndex = 0)
         {
             try
             {
-                _simConnect = new SimConnect(applicationName, IntPtr.Zero, 0, _simConnectEventHandle, 0);
+                _simConnect = new SimConnect(applicationName, IntPtr.Zero, 0, _simConnectEventHandle, configIndex);
             }
             catch (Exception e)
             {

--- a/src/CTrue.FsConnect/IFsConnect.cs
+++ b/src/CTrue.FsConnect/IFsConnect.cs
@@ -5,10 +5,10 @@ using Microsoft.FlightSimulator.SimConnect;
 namespace CTrue.FsConnect
 {
     /// <summary>
-    /// A wrapper / helper class for connection to Flight Simulator.
+    /// A wrapper / helper class for connection to Microsoft Flight Simulator.
     /// </summary>
     /// <remarks>
-    /// This wrapper supports TCP IPv4 only, for the moment.
+    /// The <see cref="IFsConnect"/> wraps the SimConnect.dll and managed 
     /// </remarks>
     public interface IFsConnect : IDisposable
     {
@@ -41,10 +41,11 @@ namespace CTrue.FsConnect
         /// Connects to Flight Simulator using an existing SimConnect.cfg.
         /// </summary>
         /// <param name="applicationName">A name identifying this client to Flight Simulator.</param>
-        void Connect(string applicationName);
+        /// <param name="configIndex">The index to a specified configuration in the SimConnect.cfg file. Default is index 0.</param>
+        void Connect(string applicationName, uint configIndex = 0);
 
         /// <summary>
-        /// Connects to Flight Simulator on the specified host name and TCP port.
+        /// Connects to Flight Simulator on the specified host name and port.
         /// </summary>
         /// <param name="applicationName">A name identifying this client to Flight Simulator.</param>
         /// <param name="hostName">A hostname or IP address.</param>

--- a/src/CTrue.FsConnect/IFsConnect.cs
+++ b/src/CTrue.FsConnect/IFsConnect.cs
@@ -33,17 +33,29 @@ namespace CTrue.FsConnect
         bool Connected { get; }
 
         /// <summary>
+        /// Gets or sets where to write the SimConnect.cfg file, that specifies how to connect to Flight Simulator.
+        /// </summary>
+        SimConnectFileLocation SimConnectFileLocation { get; set; }
+
+        /// <summary>
+        /// Connects to Flight Simulator using an existing SimConnect.cfg.
+        /// </summary>
+        /// <param name="applicationName">A name identifying this client to Flight Simulator.</param>
+        void Connect(string applicationName);
+
+        /// <summary>
         /// Connects to Flight Simulator on the specified host name and TCP port.
         /// </summary>
-        /// <param name="applicationName"></param>
-        /// <param name="hostName"></param>
-        /// <param name="port"></param>
+        /// <param name="applicationName">A name identifying this client to Flight Simulator.</param>
+        /// <param name="hostName">A hostname or IP address.</param>
+        /// <param name="port">A TCP or pipe port number.</param>
+        /// <param name="protocol">The protocol to use to connect to Flight Simulator.</param>
         /// <remarks>
-        /// A SimConnect.cfg file will be generated containing TCP connection information.
-        /// Flight Simulator must be configured for remote TCP connections by editing the SimConnect.xml file that are part of the installation.
+        /// A SimConnect.cfg file will be generated containing connection information.
+        /// Flight Simulator must be configured for remote connections by editing the SimConnect.xml file that are part of the installation.
         /// </remarks>
-        void Connect(string applicationName, string hostName, uint port);
-
+        void Connect(string applicationName, string hostName, uint port, SimConnectProtocol protocol);
+        
         /// <summary>
         /// Disconnects from Flight Simulator.
         /// </summary>

--- a/src/CTrue.FsConnect/SimConnectFileLocation.cs
+++ b/src/CTrue.FsConnect/SimConnectFileLocation.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CTrue.FsConnect
+{
+    public enum SimConnectFileLocation
+    {
+        /// <summary>
+        /// The SimConnect.cfg file will be written to the MyDocuments location.
+        /// </summary>
+        MyDocuments,
+        /// <summary>
+        /// The SimConnect.cfg file will be written to the same location that the application was started from.
+        /// </summary>
+        /// <remarks>
+        /// The application must have write access to this folder.
+        /// </remarks>
+        Local
+    }
+}

--- a/src/CTrue.FsConnect/SimConnectProtocol.cs
+++ b/src/CTrue.FsConnect/SimConnectProtocol.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CTrue.FsConnect
+{
+    /// <summary>
+    /// Specifies the protocol to use to connect to Flight Simulator.
+    /// </summary>
+    public enum SimConnectProtocol
+    {
+        /// <summary>
+        /// Named pipes
+        /// </summary>
+        Pipe,
+
+        /// <summary>
+        /// TCP.IP v4
+        /// </summary>
+        Ipv4,
+        
+        /// <summary>
+        /// TCP.IP v6
+        /// </summary>
+        Ipv6
+    }
+}

--- a/src/CTrue.FsConnect/SimProperty.cs
+++ b/src/CTrue.FsConnect/SimProperty.cs
@@ -42,7 +42,7 @@ namespace CTrue.FsConnect
         /// <summary>
         /// Creates an initialized instance using enums for known values.
         /// </summary>
-        /// <param name="name"></param>
+        /// <param name="simVar"></param>
         /// <param name="unit"></param>
         /// <param name="dataType"></param>
         public SimProperty(FsSimVar simVar, FsUnit unit, SIMCONNECT_DATATYPE dataType)


### PR DESCRIPTION
Supports:
- Using existing SimConnect.cfg if SimConnect can find it.
- Specify either start up directory or My Documents as location for SimConnect.cfg when creating it
- Specifying configuration index in SimConnect.cfg