### PR TITLE
Support for setting COM and NAV frequencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,19 @@ worldManager.SetTime(new DateTime(year, month, day, hour, minute, 0));
 
 ```
 
+### Radio Manager
+
+The radio manager currently supports setting and getting COM1 and COM2 standby and active frequencies.
+
+```csharp
+
+FsConnect fsConnect = new FsConnect();
+fsConnect.Connect("RadioManagerTest", 0);
+RadioManager radioManager = new RadioManager(_fsConnect);
+radioManager.SetCom1ActiveFrequency(freq);
+
+```
+
 ## Community
 
 * Have you find a bug? Do you have an idea for a new feature? ... [open an issue on GitHub](https://github.com/c-true/FsConnect/issues)
@@ -386,6 +399,10 @@ worldManager.SetTime(new DateTime(year, month, day, hour, minute, 0));
     * Or from your own fork
 
 ## Change log
+
+## 1.3.2
+
+* Added RadioManager, with support for setting and getting COM1 and COM2 standby and active frequencies.
 
 ## 1.3.1
 

--- a/src/CTrue.FsConnect.ExampleConsole/Program.cs
+++ b/src/CTrue.FsConnect.ExampleConsole/Program.cs
@@ -66,7 +66,7 @@ namespace FsConnectTest
 
             do
             {
-                fsConnect.RequestData(Requests.PlaneInfoRequest, planeInfoDefinitionId);
+                fsConnect.RequestData((int)Requests.PlaneInfoRequest, planeInfoDefinitionId);
                 cki = Console.ReadKey();
             } while (cki.Key != ConsoleKey.Escape);
 

--- a/src/CTrue.FsConnect.Managers.Test/AircraftManagersIntegrationTests.cs
+++ b/src/CTrue.FsConnect.Managers.Test/AircraftManagersIntegrationTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using NUnit.Framework;
+
+namespace CTrue.FsConnect.Managers.Test
+{
+    /// <summary>
+    /// World manager integration tests.
+    /// </summary>
+    /// <remarks>
+    /// Load MSFS and an aircraft before running.
+    /// Observe that the time changes in the simulator.
+    /// </remarks>
+    [TestFixture(Explicit = true)]
+    public class AircraftManagersIntegrationTests
+    {
+        [Test]
+        public void GetAircraftData()
+        {
+            // Arrange
+            AutoResetEvent resetEvent = new AutoResetEvent(false);
+            int errorCount = 0;
+
+            FsConnect fsConnect = new FsConnect();
+            fsConnect.ConnectionChanged += (sender, b) =>
+            {
+                if (b) resetEvent.Set();
+            };
+            fsConnect.FsError += (sender, args) =>
+            {
+                errorCount++;
+                Console.WriteLine($"Error: {args.ExceptionDescription}");
+            };
+
+            fsConnect.Connect("AircraftManagersIntegrationTests", 0);
+
+            bool res = resetEvent.WaitOne(2000);
+            if(!res) Assert.Fail("Not connected to MSFS within timeout");
+
+            var defId = fsConnect.RegisterDataDefinition<AircraftInfo>();
+
+            AircraftManager<AircraftInfo> aircraftManager = new AircraftManager<AircraftInfo>(fsConnect, defId);
+
+            // Act
+            var info = aircraftManager.Get();
+
+            // Assert
+            Assert.That(errorCount, Is.Zero);
+            Assert.That(info.Title, Is.Not.Empty);
+            Assert.That(info.Latitude, Is.Not.EqualTo(0));
+            Assert.That(info.Longitude, Is.Not.EqualTo(0));
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]
+    public struct AircraftInfo
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
+        public String Title;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
+        public String Category;
+        [SimVar(NameId = FsSimVar.PlaneLatitude, UnitId = FsUnit.Radian)]
+        public double Latitude;
+        [SimVar(NameId = FsSimVar.PlaneLongitude, UnitId = FsUnit.Radian)]
+        public double Longitude;
+        [SimVar(NameId = FsSimVar.PlaneAltitudeAboveGround, UnitId = FsUnit.Feet)]
+        public double AltitudeAboveGround;
+        [SimVar(NameId = FsSimVar.PlaneAltitude, UnitId = FsUnit.Feet)]
+        public double Altitude;
+        [SimVar(NameId = FsSimVar.PlaneHeadingDegreesTrue, UnitId = FsUnit.Degree)]
+        public double Heading;
+        [SimVar(NameId = FsSimVar.AirspeedTrue, UnitId = FsUnit.Knot)]
+        public double Speed;
+    };
+}

--- a/src/CTrue.FsConnect.Managers.Test/RadioManagerTests.cs
+++ b/src/CTrue.FsConnect.Managers.Test/RadioManagerTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Threading;
+using NUnit.Framework;
+
+namespace CTrue.FsConnect.Managers.Test
+{
+    /// <summary>
+    /// Radio manager integration tests.
+    /// </summary>
+    /// <remarks>
+    /// Load MSFS and an aircraft before running.
+    /// </remarks>
+    [TestFixture(Explicit = true)]
+    public class RadioManagerTests
+    {
+        [Test]
+        public void SetComStandbyFrequencies()
+        {
+            // Arrange
+            AutoResetEvent resetEvent = new AutoResetEvent(false);
+            int errorCount = 0;
+
+            FsConnect fsConnect = new FsConnect();
+            fsConnect.ConnectionChanged += (sender, b) =>
+            {
+                if (b) resetEvent.Set();
+            };
+            fsConnect.FsError += (sender, args) =>
+            {
+                errorCount++;
+                Console.WriteLine($"Error: {args.ExceptionDescription}");
+            };
+
+            fsConnect.Connect("FsConnectManagersIntegrationTest", 0);
+
+            bool res = resetEvent.WaitOne(2000);
+            if(!res) Assert.Fail("Not connected to MSFS within timeout");
+
+            RadioManager manager = new RadioManager(fsConnect);
+
+            // Act
+
+            // Values
+            uint x = 0x2797;
+            uint y = 0x3625;
+            uint z = 0x2407;
+
+            manager.SetCom1StandbyFrequency(x);
+            manager.SetCom2StandbyFrequency(y);
+
+            fsConnect.SetText("Observe COM1&COM2 Standby frequencies have changed", 1000);
+
+            // Assert
+            Assert.That(errorCount, Is.Zero);
+        }
+    }
+}

--- a/src/CTrue.FsConnect.Managers.Test/RadioManagerTests.cs
+++ b/src/CTrue.FsConnect.Managers.Test/RadioManagerTests.cs
@@ -13,127 +13,102 @@ namespace CTrue.FsConnect.Managers.Test
     [TestFixture(Explicit = true)]
     public class RadioManagerTests
     {
-        [Test]
-        public void SetCom1StandbyFrequencies()
+        private FsConnect _fsConnect;
+        private RadioManager _manager;
+
+        [SetUp]
+        public void SetUp()
         {
-            // Arrange
             AutoResetEvent resetEvent = new AutoResetEvent(false);
 
-            FsConnect fsConnect = new FsConnect();
-            fsConnect.ConnectionChanged += (sender, b) =>
+            _fsConnect = new FsConnect();
+            _fsConnect.ConnectionChanged += (sender, b) =>
             {
                 if (b) resetEvent.Set();
             };
-            fsConnect.FsError += (sender, args) =>
+            _fsConnect.FsError += (sender, args) =>
             {
                 Assert.Fail($"MSFS Error: {args.ExceptionDescription}");
             };
 
-            fsConnect.Connect("FsConnectManagersIntegrationTest", 0);
+            _fsConnect.Connect("RadioManagerIntegrationTest", 0);
 
             bool res = resetEvent.WaitOne(2000);
             if (!res) Assert.Fail("Not connected to MSFS within timeout");
 
-            RadioManager manager = new RadioManager(fsConnect);
-
-            // Set - Act
-
-            double freq = 124.75d;
-
-            manager.SetCom1StandbyFrequency(freq);
-
-            // Set - Assert
-            manager.Update();
-            Assert.That(manager.Com1StandbyFrequency, Is.EqualTo(freq));
-
-            // Swap - Act
-            manager.Com1Swap();
-
-            // Swap - Assert
-            manager.Update();
-            Assert.That(manager.Com1ActiveFrequency, Is.EqualTo(freq));
+            _manager = new RadioManager(_fsConnect);
         }
 
         [Test]
-        public void SetCom2StandbyFrequencies()
+        public void SetCom1StandbyFrequency()
         {
             // Arrange
-            AutoResetEvent resetEvent = new AutoResetEvent(false);
+            double freq = 124.774d;
 
-            FsConnect fsConnect = new FsConnect();
-            fsConnect.ConnectionChanged += (sender, b) =>
-            {
-                if (b) resetEvent.Set();
-            };
-            fsConnect.FsError += (sender, args) =>
-            {
-                Assert.Fail($"MSFS Error: {args.ExceptionDescription}");
-            };
+            // Act
+            _manager.SetCom1StandbyFrequency(freq);
 
-            fsConnect.Connect("FsConnectManagersIntegrationTest", 0);
-
-            bool res = resetEvent.WaitOne(2000);
-            if (!res) Assert.Fail("Not connected to MSFS within timeout");
-
-            RadioManager manager = new RadioManager(fsConnect);
-
-            // Set - Act
-
-            double freq = 118.10d;
-
-            manager.SetCom2StandbyFrequency(freq);
-
-            // Set - Assert
-            manager.Update();
-            Assert.That(manager.Com2StandbyFrequency, Is.EqualTo(freq).Within(0.01));
-
-            // Swap - Act
-            manager.Com2Swap();
-
-            // Swap - Assert
-            manager.Update();
-            Assert.That(manager.Com2ActiveFrequency, Is.EqualTo(freq).Within(0.01));
+            // Assert
+            _manager.Update();
+            Assert.That(_manager.Com1StandbyFrequency, Is.EqualTo(freq));
         }
 
         [Test]
-        public void SetCom1StandbyFrequenciesInHz()
+        public void SetCom1ActiveFrequency()
         {
             // Arrange
-            AutoResetEvent resetEvent = new AutoResetEvent(false);
+            double freq = 124.774d;
 
-            FsConnect fsConnect = new FsConnect();
-            fsConnect.ConnectionChanged += (sender, b) =>
-            {
-                if (b) resetEvent.Set();
-            };
-            fsConnect.FsError += (sender, args) =>
-            {
-                Assert.Fail($"MSFS Error: {args.ExceptionDescription}");
-            };
+            // Act
+            _manager.SetCom1ActiveFrequency(freq);
 
-            fsConnect.Connect("FsConnectManagersIntegrationTest", 0);
+            // Assert
+            _manager.Update();
+            Assert.That(_manager.Com1ActiveFrequency, Is.EqualTo(freq));
+        }
 
-            bool res = resetEvent.WaitOne(2000);
-            if (!res) Assert.Fail("Not connected to MSFS within timeout");
+        [Test]
+        public void SetCom2StandbyFrequency()
+        {
+            // Arrange
+            double freq = 124.774d;
 
-            RadioManager manager = new RadioManager(fsConnect);
+            // Act
+            _manager.SetCom2StandbyFrequency(freq);
 
-            // Set - Act
+            // Assert
+            _manager.Update();
+            Assert.That(_manager.Com2StandbyFrequency, Is.EqualTo(freq));
+        }
 
-            double freq = 124.775d;
+        [Test]
+        public void SetCom2ActiveFrequency()
+        {
+            // Arrange
+            double freq = 124.773d;
 
-            manager.SetCom1StandbyFrequencyInHz(freq);
+            // Act
+            _manager.SetCom2ActiveFrequency(freq);
 
-            //// Set - Assert
-            //manager.Update();
-            //Assert.That(manager.Com1StandbyFrequency, Is.EqualTo(freq));
+            // Assert
+            _manager.Update();
+            Assert.That(_manager.Com2ActiveFrequency, Is.EqualTo(freq));
+        }
 
-            //// Swap - Act
-            //manager.Com1Swap();
+        [Test]
+        public void SwapCom1()
+        {
+            // Arrange
+            double freq = 124.773d;
+            _manager.SetCom1StandbyFrequency(freq);
+            _manager.SetCom1ActiveFrequency(125.000d);
 
-            //// Swap - Assert
-            //manager.Update();
-            //Assert.That(manager.Com1ActiveFrequency, Is.EqualTo(freq));
+            // Act
+            _manager.Com1Swap();
+
+            // Assert
+            _manager.Update();
+            Assert.That(_manager.Com1ActiveFrequency, Is.EqualTo(freq));
         }
     }
 }

--- a/src/CTrue.FsConnect.Managers.Test/RadioManagerTests.cs
+++ b/src/CTrue.FsConnect.Managers.Test/RadioManagerTests.cs
@@ -110,5 +110,21 @@ namespace CTrue.FsConnect.Managers.Test
             _manager.Update();
             Assert.That(_manager.Com1ActiveFrequency, Is.EqualTo(freq));
         }
+
+        [Test]
+        public void SwapCom2()
+        {
+            // Arrange
+            double freq = 124.773d;
+            _manager.SetCom2StandbyFrequency(freq);
+            _manager.SetCom2ActiveFrequency(125.000d);
+
+            // Act
+            _manager.Com2Swap();
+
+            // Assert
+            _manager.Update();
+            Assert.That(_manager.Com2ActiveFrequency, Is.EqualTo(freq));
+        }
     }
 }

--- a/src/CTrue.FsConnect.Managers.Test/RadioManagerTests.cs
+++ b/src/CTrue.FsConnect.Managers.Test/RadioManagerTests.cs
@@ -94,5 +94,46 @@ namespace CTrue.FsConnect.Managers.Test
             manager.Update();
             Assert.That(manager.Com2ActiveFrequency, Is.EqualTo(freq).Within(0.01));
         }
+
+        [Test]
+        public void SetCom1StandbyFrequenciesInHz()
+        {
+            // Arrange
+            AutoResetEvent resetEvent = new AutoResetEvent(false);
+
+            FsConnect fsConnect = new FsConnect();
+            fsConnect.ConnectionChanged += (sender, b) =>
+            {
+                if (b) resetEvent.Set();
+            };
+            fsConnect.FsError += (sender, args) =>
+            {
+                Assert.Fail($"MSFS Error: {args.ExceptionDescription}");
+            };
+
+            fsConnect.Connect("FsConnectManagersIntegrationTest", 0);
+
+            bool res = resetEvent.WaitOne(2000);
+            if (!res) Assert.Fail("Not connected to MSFS within timeout");
+
+            RadioManager manager = new RadioManager(fsConnect);
+
+            // Set - Act
+
+            double freq = 124.775d;
+
+            manager.SetCom1StandbyFrequencyInHz(freq);
+
+            //// Set - Assert
+            //manager.Update();
+            //Assert.That(manager.Com1StandbyFrequency, Is.EqualTo(freq));
+
+            //// Swap - Act
+            //manager.Com1Swap();
+
+            //// Swap - Assert
+            //manager.Update();
+            //Assert.That(manager.Com1ActiveFrequency, Is.EqualTo(freq));
+        }
     }
 }

--- a/src/CTrue.FsConnect.Managers.Test/RadioManagerTests.cs
+++ b/src/CTrue.FsConnect.Managers.Test/RadioManagerTests.cs
@@ -50,8 +50,12 @@ namespace CTrue.FsConnect.Managers.Test
 
             fsConnect.SetText("Observe COM1&COM2 Standby frequencies have changed", 1000);
 
+            manager.Update();
+            
             // Assert
             Assert.That(errorCount, Is.Zero);
+            Assert.That(manager.Com1StandbyFrequency, Is.EqualTo(2797));
+            Assert.That(manager.Com2StandbyFrequency, Is.EqualTo(3625));
         }
     }
 }

--- a/src/CTrue.FsConnect.Managers.Test/WorldManagerIntegrationTests.cs
+++ b/src/CTrue.FsConnect.Managers.Test/WorldManagerIntegrationTests.cs
@@ -12,7 +12,7 @@ namespace CTrue.FsConnect.Managers.Test
     /// Observe that the time changes in the simulator.
     /// </remarks>
     [TestFixture(Explicit = true)]
-    public class FsConnectManagersIntegrationTests
+    public class WorldManagerIntegrationTests
     {
         [Test]
         public void SetTime_SetsTimeInMSFS()
@@ -32,7 +32,7 @@ namespace CTrue.FsConnect.Managers.Test
                 Console.WriteLine($"Error: {args.ExceptionDescription}");
             };
 
-            fsConnect.Connect("FsConnectManagersIntegrationTest", 0);
+            fsConnect.Connect("WorldManagerIntegrationTests", 0);
 
             bool res = resetEvent.WaitOne(2000);
             if(!res) Assert.Fail("Not connected to MSFS within timeout");

--- a/src/CTrue.FsConnect.Managers/AircraftManager.cs
+++ b/src/CTrue.FsConnect.Managers/AircraftManager.cs
@@ -77,6 +77,26 @@ namespace CTrue.FsConnect.Managers
         /// Creates an instance of the <see cref="AircraftManager{T}"/> class.
         /// </summary>
         /// <param name="fsConnect"></param>
+        public AircraftManager(IFsConnect fsConnect, int defineId)
+            : this(fsConnect, defineId, fsConnect.GetNextId())
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="AircraftManager{T}"/> class.
+        /// </summary>
+        /// <param name="fsConnect"></param>
+        /// <param name="defineId">The definition used when registering the aircraft information structure.</param>
+        /// <param name="requestId">The request Id to use when requesting data using the manager.</param>
+        public AircraftManager(IFsConnect fsConnect, int defineId, int requestId)
+        : this(fsConnect, (FsConnectEnum)defineId, (FsConnectEnum)requestId)
+        {
+        }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="AircraftManager{T}"/> class.
+        /// </summary>
+        /// <param name="fsConnect"></param>
         /// <param name="defineId">The definition used when registering the aircraft information structure.</param>
         /// <param name="requestId">The request Id to use when requesting data using the manager.</param>
         public AircraftManager(IFsConnect fsConnect, Enum defineId, Enum requestId)

--- a/src/CTrue.FsConnect.Managers/CTrue.FsConnect.Managers.csproj
+++ b/src/CTrue.FsConnect.Managers/CTrue.FsConnect.Managers.csproj
@@ -11,6 +11,7 @@
         - Aircraft information
         - Retrieving sim objects
         - Setting world time
+        - Controlling COM radios
     </Description>
     <Authors>C-True</Authors>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -20,7 +21,7 @@
     <PackageTags>msfs flight-simulator simconnect</PackageTags>
     <Version>1.3.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes />
+    <PackageReleaseNotes>Added RadioManager for controlling COM radios.</PackageReleaseNotes>
     <AssemblyVersion>1.3.2.0</AssemblyVersion>
     <FileVersion>1.3.2.0</FileVersion>
   </PropertyGroup>

--- a/src/CTrue.FsConnect.Managers/CTrue.FsConnect.Managers.csproj
+++ b/src/CTrue.FsConnect.Managers/CTrue.FsConnect.Managers.csproj
@@ -18,11 +18,11 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/c-true/FsConnect</RepositoryUrl>
     <PackageTags>msfs flight-simulator simconnect</PackageTags>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes />
-    <AssemblyVersion>1.3.1.0</AssemblyVersion>
-    <FileVersion>1.3.1.0</FileVersion>
+    <AssemblyVersion>1.3.2.0</AssemblyVersion>
+    <FileVersion>1.3.2.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/CTrue.FsConnect.Managers/RadioManager.cs
+++ b/src/CTrue.FsConnect.Managers/RadioManager.cs
@@ -8,25 +8,64 @@ namespace CTrue.FsConnect.Managers
     /// <summary>
     /// The <see cref="IRadioManager"/> controls the navigation and communication radios in the current aircraft.
     /// </summary>
+    /// <remarks>
+    /// Note: Currently only 2 decimal frequencies, e.g. 120.25 are supported, not 3 decimal frequencies such as 128.725
+    /// </remarks>
     public interface IRadioManager
     {
         /// <summary>
-        /// Sets the COM1 frequency using BCD16 value.
+        /// Gets the COM1 Active frequency as returned from the last call with <see cref="IRadioManager.Update()"/>.
         /// </summary>
-        /// <param name="frequency">The BCD16 value, omitting the leading 1. E.g. 0x2400 equals 124.00</param>
         /// <remarks>
-        /// Currently supports 0.025 MHz increments, so 0x2407 equals 124.075
+        /// The active frequency is changed by setting the COM1 standby frequency and calling <see cref="IRadioManager.COM1Swap()"/>
         /// </remarks>
-        void SetCom1StandbyFrequency(uint frequency);
+        double Com1ActiveFrequency { get; }
 
         /// <summary>
-        /// Sets the COM2 frequency using BCD16 value.
+        /// Gets the COM1 Standby frequency as returned from the last call with <see cref="IRadioManager.Update()"/>.
         /// </summary>
-        /// <param name="frequency">The BCD16 value, omitting the leading 1. E.g. 0x2400 equals 124.00</param>
+        double Com1StandbyFrequency { get; }
+
+        /// <summary>
+        /// Gets the COM2 Active frequency as returned from the last call with <see cref="IRadioManager.Update()"/>.
+        /// </summary>
         /// <remarks>
-        /// Currently supports 0.025 MHz increments, so 0x2407 equals 124.075
+        /// The active frequency is changed by setting the COM2 standby frequency and calling <see cref="IRadioManager.COM2Swap()"/>
         /// </remarks>
-        void SetCom2StandbyFrequency(uint frequency);
+        double Com2ActiveFrequency { get; }
+
+        /// <summary>
+        /// Gets the COM2 Standby frequency as returned from the last call with <see cref="IRadioManager.Update()"/>.
+        /// </summary>
+        double Com2StandbyFrequency { get; }
+
+        /// <summary>
+        /// Sets the COM1 standby frequency.
+        /// </summary>
+        /// <param name="frequency">The frequency, in MHz, e.g. 124.10</param>
+        /// <remarks>
+        /// Currently supports 0.25 MHz increments.
+        /// </remarks>
+        void SetCom1StandbyFrequency(double frequency);
+
+        /// <summary>
+        /// Sets the COM2 standby frequency.
+        /// </summary>
+        /// <param name="frequency">The frequency, in MHz, e.g. 124.10</param>
+        /// <remarks>
+        /// Currently supports 0.25 MHz increments.
+        /// </remarks>
+        void SetCom2StandbyFrequency(double frequency);
+
+        /// <summary>
+        /// Swaps COMS1 active and standby frequency.
+        /// </summary>
+        void Com1Swap();
+
+        /// <summary>
+        /// Swaps COMS2 active and standby frequency.
+        /// </summary>
+        void Com2Swap();
     }
 
     /// <inheritdoc />
@@ -36,29 +75,38 @@ namespace CTrue.FsConnect.Managers
         private AutoResetEvent _resetEvent = new AutoResetEvent(false);
         private int _groupId;
         private int _com1StbyRadioSetEventId;
+        private int _com1StbySwapEventId;
+
         private int _com2StbyRadioSetEventId;
+        private int _com2StbySwapEventId;
 
         private RadioManagerSimVars _radioManagerSimVars = new RadioManagerSimVars();
         private int _radioManagerSimVarsReqId;
         private int _radioManagerSimVarsDefId;
-        
-        public uint Com1StandbyFrequency
-        {
-            get => Bcd.Bcd2Dec(_radioManagerSimVars.Com1StandbyFrequency);
-            set => SetCom1StandbyFrequency(value);
-        }
 
-        public uint Com2StandbyFrequency
-        {
-            get => Bcd.Bcd2Dec(_radioManagerSimVars.Com2StandbyFrequency);
-            set => SetCom2StandbyFrequency(value);
-        }
+        public double Com1ActiveFrequency {  get; private set; }
+
+        public double Com1StandbyFrequency { get; private set; }
+
+        public double Com2ActiveFrequency { get; private set; }
+
+        public double Com2StandbyFrequency { get; private set; }
 
         public RadioManager(IFsConnect fsConnect)
         {
             _fsConnect = fsConnect;
 
             RegisterEvents();
+        }
+
+        public void Com1Swap()
+        {
+            _fsConnect.TransmitClientEvent(_com1StbySwapEventId, 0, _groupId);
+        }
+
+        public void Com2Swap()
+        {
+            _fsConnect.TransmitClientEvent(_com2StbySwapEventId, 0, _groupId);
         }
 
         private void RegisterEvents()
@@ -69,9 +117,15 @@ namespace CTrue.FsConnect.Managers
             _com1StbyRadioSetEventId = _fsConnect.GetNextId();
             _fsConnect.MapClientEventToSimEvent(_groupId, _com1StbyRadioSetEventId, FsEventNameId.ComStbyRadioSet);
 
+            _com1StbySwapEventId = _fsConnect.GetNextId();
+            _fsConnect.MapClientEventToSimEvent(_groupId, _com1StbySwapEventId, FsEventNameId.ComStbyRadioSwitchTo);
+
             _com2StbyRadioSetEventId = _fsConnect.GetNextId();
             _fsConnect.MapClientEventToSimEvent(_groupId, _com2StbyRadioSetEventId, FsEventNameId.Com2StbyRadioSet);
-            
+
+            _com2StbySwapEventId = _fsConnect.GetNextId();
+            _fsConnect.MapClientEventToSimEvent(_groupId, _com2StbySwapEventId, FsEventNameId.Com2RadioSwap);
+
             _fsConnect.SetNotificationGroupPriority(_groupId);
 
             _radioManagerSimVarsReqId = _fsConnect.GetNextId();
@@ -94,28 +148,42 @@ namespace CTrue.FsConnect.Managers
 
             if(!resetRes)
                 throw new TimeoutException("Radio Manager data was not returned from MSFS within timeout");
+
+            Com1ActiveFrequency = new FrequencyBcd(_radioManagerSimVars.Com1ActiveFrequency).Value;
+            Com1StandbyFrequency = new FrequencyBcd(_radioManagerSimVars.Com1StandbyFrequency).Value;
+            Com2ActiveFrequency = new FrequencyBcd(_radioManagerSimVars.Com2ActiveFrequency).Value;
+            Com2StandbyFrequency = new FrequencyBcd(_radioManagerSimVars.Com2StandbyFrequency).Value;
         }
 
         /// <inheritdoc />
-        public void SetCom1StandbyFrequency(uint frequency)
+        public void SetCom1StandbyFrequency(double frequency)
         {
-            _fsConnect.TransmitClientEvent(_com1StbyRadioSetEventId, frequency, _groupId);
+            FrequencyBcd freqBcd = new FrequencyBcd(frequency);
+            _fsConnect.TransmitClientEvent(_com1StbyRadioSetEventId, freqBcd.BcdValue, _groupId);
         }
 
         /// <inheritdoc />
-        public void SetCom2StandbyFrequency(uint frequency)
+        public void SetCom2StandbyFrequency(double frequency)
         {
-            _fsConnect.TransmitClientEvent(_com2StbyRadioSetEventId, frequency, _groupId);
+            FrequencyBcd freqBcd = new FrequencyBcd(frequency);
+            _fsConnect.TransmitClientEvent(_com2StbyRadioSetEventId, freqBcd.BcdValue, _groupId);
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]
         public struct RadioManagerSimVars
         {
+            [SimVar(NameId = FsSimVar.ComActiveFrequency, UnitId = FsUnit.FrequencyBcd16, Instance = 1)]
+            public uint Com1ActiveFrequency;
+
             [SimVar(NameId = FsSimVar.ComStandbyFrequency, UnitId = FsUnit.FrequencyBcd16, Instance = 1)]
             public uint Com1StandbyFrequency;
+            
+            [SimVar(NameId = FsSimVar.ComActiveFrequency, UnitId = FsUnit.FrequencyBcd16, Instance = 2)]
+            public uint Com2ActiveFrequency;
 
             [SimVar(NameId = FsSimVar.ComStandbyFrequency, UnitId = FsUnit.FrequencyBcd16, Instance = 2)]
             public uint Com2StandbyFrequency;
+
         }
     }
 }

--- a/src/CTrue.FsConnect.Managers/RadioManager.cs
+++ b/src/CTrue.FsConnect.Managers/RadioManager.cs
@@ -45,8 +45,11 @@ namespace CTrue.FsConnect.Managers
         /// <param name="frequency">The frequency, in MHz, e.g. 124.10</param>
         /// <remarks>
         /// Currently supports 0.25 MHz increments.
+        /// Range: 118.000 to 135.975Mhz
         /// </remarks>
         void SetCom1StandbyFrequency(double frequency);
+
+        void SetCom1StandbyFrequencyInHz(double frequency);
 
         /// <summary>
         /// Sets the COM2 standby frequency.
@@ -54,8 +57,11 @@ namespace CTrue.FsConnect.Managers
         /// <param name="frequency">The frequency, in MHz, e.g. 124.10</param>
         /// <remarks>
         /// Currently supports 0.25 MHz increments.
+        /// Range: 118.000 to 135.975Mhz
         /// </remarks>
         void SetCom2StandbyFrequency(double frequency);
+
+        void SetCom2StandbyFrequencyInHz(double frequency);
 
         /// <summary>
         /// Swaps COMS1 active and standby frequency.
@@ -75,9 +81,11 @@ namespace CTrue.FsConnect.Managers
         private AutoResetEvent _resetEvent = new AutoResetEvent(false);
         private int _groupId;
         private int _com1StbyRadioSetEventId;
+        private int _com1StbyRadioSetHzEventId;
         private int _com1StbySwapEventId;
 
         private int _com2StbyRadioSetEventId;
+        private int _com2StbyRadioSetHzEventId;
         private int _com2StbySwapEventId;
 
         private RadioManagerSimVars _radioManagerSimVars = new RadioManagerSimVars();
@@ -117,11 +125,17 @@ namespace CTrue.FsConnect.Managers
             _com1StbyRadioSetEventId = _fsConnect.GetNextId();
             _fsConnect.MapClientEventToSimEvent(_groupId, _com1StbyRadioSetEventId, FsEventNameId.ComStbyRadioSet);
 
+            _com1StbyRadioSetHzEventId = _fsConnect.GetNextId();
+            _fsConnect.MapClientEventToSimEvent(_groupId, _com1StbyRadioSetHzEventId, FsEventNameId.ComRadioSetHz);
+
             _com1StbySwapEventId = _fsConnect.GetNextId();
             _fsConnect.MapClientEventToSimEvent(_groupId, _com1StbySwapEventId, FsEventNameId.ComStbyRadioSwitchTo);
 
             _com2StbyRadioSetEventId = _fsConnect.GetNextId();
             _fsConnect.MapClientEventToSimEvent(_groupId, _com2StbyRadioSetEventId, FsEventNameId.Com2StbyRadioSet);
+
+            _com2StbyRadioSetHzEventId = _fsConnect.GetNextId();
+            _fsConnect.MapClientEventToSimEvent(_groupId, _com2StbyRadioSetHzEventId, FsEventNameId.Com2RadioSetHz);
 
             _com2StbySwapEventId = _fsConnect.GetNextId();
             _fsConnect.MapClientEventToSimEvent(_groupId, _com2StbySwapEventId, FsEventNameId.Com2RadioSwap);
@@ -159,14 +173,28 @@ namespace CTrue.FsConnect.Managers
         public void SetCom1StandbyFrequency(double frequency)
         {
             FrequencyBcd freqBcd = new FrequencyBcd(frequency);
-            _fsConnect.TransmitClientEvent(_com1StbyRadioSetEventId, freqBcd.BcdValue, _groupId);
+            _fsConnect.TransmitClientEvent(_com1StbyRadioSetEventId, freqBcd.Bcd16Value, _groupId);
+        }
+
+        /// <inheritdoc />
+        public void SetCom1StandbyFrequencyInHz(double frequency)
+        {
+            FrequencyBcd freqBcd = new FrequencyBcd(frequency);
+            _fsConnect.TransmitClientEvent(_com1StbyRadioSetHzEventId, freqBcd.Bcd32Value, _groupId);
         }
 
         /// <inheritdoc />
         public void SetCom2StandbyFrequency(double frequency)
         {
             FrequencyBcd freqBcd = new FrequencyBcd(frequency);
-            _fsConnect.TransmitClientEvent(_com2StbyRadioSetEventId, freqBcd.BcdValue, _groupId);
+            _fsConnect.TransmitClientEvent(_com2StbyRadioSetEventId, freqBcd.Bcd16Value, _groupId);
+        }
+
+        /// <inheritdoc />
+        public void SetCom2StandbyFrequencyInHz(double frequency)
+        {
+            FrequencyBcd freqBcd = new FrequencyBcd(frequency);
+            _fsConnect.TransmitClientEvent(_com2StbyRadioSetHzEventId, freqBcd.Bcd32Value, _groupId);
         }
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]

--- a/src/CTrue.FsConnect.Managers/RadioManager.cs
+++ b/src/CTrue.FsConnect.Managers/RadioManager.cs
@@ -1,0 +1,67 @@
+﻿namespace CTrue.FsConnect.Managers
+{
+    /// <summary>
+    /// The <see cref="IRadioManager"/> controls the navigation and communication radios in the current aircraft.
+    /// </summary>
+    public interface IRadioManager
+    {
+        /// <summary>
+        /// Sets the COM1 frequency using BCD16 value.
+        /// </summary>
+        /// <param name="frequency">The BCD16 value, omitting the leading 1. E.g. 0x2400 equals 124.00</param>
+        /// <remarks>
+        /// Currently supports 0.025 MHz increments, so 0x2407 equals 124.075
+        /// </remarks>
+        void SetCom1StandbyFrequency(uint frequency);
+
+        /// <summary>
+        /// Sets the COM2 frequency using BCD16 value.
+        /// </summary>
+        /// <param name="frequency">The BCD16 value, omitting the leading 1. E.g. 0x2400 equals 124.00</param>
+        /// <remarks>
+        /// Currently supports 0.025 MHz increments, so 0x2407 equals 124.075
+        /// </remarks>
+        void SetCom2StandbyFrequency(uint frequency);
+    }
+
+    /// <inheritdoc />
+    public class RadioManager : IRadioManager
+    {
+        private readonly IFsConnect _fsConnect;
+        private int _groupId;
+        private int _com1StbyRadioSetEventId;
+        private int _com2StbyRadioSetEventId;
+
+        public RadioManager(IFsConnect fsConnect)
+        {
+            _fsConnect = fsConnect;
+
+            RegisterEvents();
+        }
+
+        private void RegisterEvents()
+        {
+            _groupId = _fsConnect.GetNextId();
+
+            _com1StbyRadioSetEventId = _fsConnect.GetNextId();
+            _fsConnect.MapClientEventToSimEvent(_groupId, _com1StbyRadioSetEventId, FsEventNameId.ComStbyRadioSet);
+
+            _com2StbyRadioSetEventId = _fsConnect.GetNextId();
+            _fsConnect.MapClientEventToSimEvent(_groupId, _com2StbyRadioSetEventId, FsEventNameId.Com2StbyRadioSet);
+            
+            _fsConnect.SetNotificationGroupPriority(_groupId);
+        }
+
+        /// <inheritdoc />
+        public void SetCom1StandbyFrequency(uint frequency)
+        {
+            _fsConnect.TransmitClientEvent(_com1StbyRadioSetEventId, frequency, _groupId);
+        }
+
+        /// <inheritdoc />
+        public void SetCom2StandbyFrequency(uint frequency)
+        {
+            _fsConnect.TransmitClientEvent(_com2StbyRadioSetEventId, frequency, _groupId);
+        }
+    }
+}

--- a/src/CTrue.FsConnect.Test/BcdTests.cs
+++ b/src/CTrue.FsConnect.Test/BcdTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace CTrue.FsConnect.Test
+{
+    [TestFixture]
+    public class BcdTests
+    {
+        [Test]
+        public void Test()
+        {
+            /*
+            def to_radio_bcd16(val):
+              encodable = int(val * 100)
+              remainder = ((val * 100) - encodable) / 100.0
+              return int(str(encodable), 16), round(remainder,3), val
+             */
+            double freq = 128.775;
+            uint freq1 = (uint)(freq * 100);
+            double remainder = ((freq * 100) - freq1) / 100.0;
+            var bcd = Bcd.Dec2Bcd(freq1);
+            var freq2 = Bcd.Bcd2Dec(bcd);
+            
+
+            Assert.That(freq2, Is.EqualTo(freq1));
+
+            //Assert.That(ToRadioBcd(128.775), Is.EqualTo(75895));
+
+        }
+
+        [Test]
+        public void Test2()
+        {
+            double freq = 128.775;
+
+            // Act
+            var bcd = Bcd.Dec2Bcd(freq);
+
+            // Assert
+            var freqOutUint = Bcd.Bcd2Dec(bcd);
+            var freqOutDouble = (double)freqOutUint / 100;
+            
+            Assert.That(freqOutDouble, Is.EqualTo(freq));
+        }
+    }
+}

--- a/src/CTrue.FsConnect.Test/FrequencyBcdTest.cs
+++ b/src/CTrue.FsConnect.Test/FrequencyBcdTest.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+
+namespace CTrue.FsConnect.Test
+{
+    [TestFixture]
+    public class FrequencyBcdTest
+    {
+        [Test]
+        public void Test()
+        {
+            FrequencyBcd freq = new FrequencyBcd(128.775);
+
+            Assert.That(freq.BcdValue, Is.EqualTo(75895));
+
+            FrequencyBcd freq2 = new FrequencyBcd(freq.BcdValue);
+
+            Assert.That(freq2.Value, Is.EqualTo(128.75));
+        }
+
+        [Test]
+        public void Test2([Values(124.00, 127.90)] double frequency)
+        {
+            // Act
+            FrequencyBcd freq = new FrequencyBcd(frequency);
+            FrequencyBcd freq2 = new FrequencyBcd(freq.BcdValue);
+
+            // Assert
+            Assert.That(freq2.Value, Is.EqualTo(frequency));
+        }
+    }
+}

--- a/src/CTrue.FsConnect.Test/FrequencyBcdTest.cs
+++ b/src/CTrue.FsConnect.Test/FrequencyBcdTest.cs
@@ -10,9 +10,9 @@ namespace CTrue.FsConnect.Test
         {
             FrequencyBcd freq = new FrequencyBcd(128.775);
 
-            Assert.That(freq.BcdValue, Is.EqualTo(75895));
+            Assert.That(freq.Bcd16Value, Is.EqualTo(75895));
 
-            FrequencyBcd freq2 = new FrequencyBcd(freq.BcdValue);
+            FrequencyBcd freq2 = new FrequencyBcd(freq.Bcd16Value);
 
             Assert.That(freq2.Value, Is.EqualTo(128.75));
         }
@@ -22,7 +22,7 @@ namespace CTrue.FsConnect.Test
         {
             // Act
             FrequencyBcd freq = new FrequencyBcd(frequency);
-            FrequencyBcd freq2 = new FrequencyBcd(freq.BcdValue);
+            FrequencyBcd freq2 = new FrequencyBcd(freq.Bcd16Value);
 
             // Assert
             Assert.That(freq2.Value, Is.EqualTo(frequency));

--- a/src/CTrue.FsConnect.Test/FsConnectIntegrationTest.cs
+++ b/src/CTrue.FsConnect.Test/FsConnectIntegrationTest.cs
@@ -60,7 +60,7 @@ namespace CTrue.FsConnect.Test
                 resetEvent.Set();
             };
 
-            fsConnect.RequestData(TestEnums.RequestId, hbDef);
+            fsConnect.RequestData((int)TestEnums.RequestId, hbDef);
             res = resetEvent.WaitOne(2000);
             if (!res) Assert.Fail("Data not returned from MSFS within timeout");
 

--- a/src/CTrue.FsConnect.Test/FsConnectIntegrationTest.cs
+++ b/src/CTrue.FsConnect.Test/FsConnectIntegrationTest.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.FlightSimulator.SimConnect;
+using NUnit.Framework;
+namespace CTrue.FsConnect.Test
+{
+    [TestFixture, Explicit]
+    public class FsConnectIntegrationTest
+    {
+        enum TestEnums
+        {
+            GroupId = 1234,
+            EventId = 1235,
+            RequestId
+        }
+
+        [Test]
+        public void TransmitClientEvent_HeadingBugDirectionSet_SetsHeadingBugDirection()
+        {
+            // Arrange
+            AutoResetEvent resetEvent = new AutoResetEvent(false);
+            int errorCount = 0;
+            
+            FsConnect fsConnect = new FsConnect();
+            fsConnect.ConnectionChanged += (sender, b) =>
+            {
+                if (b) resetEvent.Set();
+            };
+            
+            fsConnect.FsError += (sender, args) =>
+            {
+                errorCount++;
+                Console.WriteLine($"Error: {args.ExceptionDescription}");
+            };
+            
+            fsConnect.Connect("FsConnectIntegrationTest", 0);
+            bool res = resetEvent.WaitOne(2000);
+            if (!res) Assert.Fail("Not connected to MSFS within timeout");
+
+            var hbDef = fsConnect.RegisterDataDefinition<HeadingBugTest>();
+            HeadingBugTest headingBugData = default;
+
+            // Act
+            fsConnect.MapClientEventToSimEvent(TestEnums.GroupId, TestEnums.EventId, FsEventNameId.HeadingBugSet);
+            fsConnect.SetNotificationGroupPriority(TestEnums.GroupId);
+            uint headingValue = (uint)DateTime.Now.Second * 6;
+            fsConnect.TransmitClientEvent(TestEnums.EventId, (uint)headingValue, TestEnums.GroupId);
+            
+            // Assert
+            Assert.That(errorCount, Is.Zero, "MSFS returned errors. Check console output.");
+
+            fsConnect.FsDataReceived += (sender, args) =>
+            {
+                var data = args.Data.FirstOrDefault();
+
+                headingBugData = data is HeadingBugTest ? (HeadingBugTest) data : default;
+
+                resetEvent.Set();
+            };
+
+            fsConnect.RequestData(TestEnums.RequestId, hbDef);
+            res = resetEvent.WaitOne(2000);
+            if (!res) Assert.Fail("Data not returned from MSFS within timeout");
+
+            Assert.That(headingBugData, Is.Not.Null);
+            Assert.That(headingBugData.HeadingBug, Is.EqualTo(headingValue));
+
+            // Teardown
+            fsConnect?.Disconnect();
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]
+    public struct HeadingBugTest
+    {
+        [SimVar(NameId = FsSimVar.AutopilotHeadingLockDir, UnitId = FsUnit.Degree)]
+        public double HeadingBug;
+    }
+}

--- a/src/CTrue.FsConnect/Bcd.cs
+++ b/src/CTrue.FsConnect/Bcd.cs
@@ -1,0 +1,31 @@
+﻿namespace CTrue.FsConnect
+{
+    /// <summary>
+    /// Handles the BCD format
+    /// </summary>
+    public static class Bcd
+    {
+        /// <summary>
+        /// Converts from binary coded decimal to integer
+        /// </summary>
+        /// <param name="num"></param>
+        /// <returns></returns>
+        public static uint Bcd2Dec(uint num) { return HornerScheme(num, 0x10, 10); }
+
+        /// <summary>
+        /// Converts from integer to binary coded decimal
+        /// </summary>
+        /// <param name="num"></param>
+        /// <returns></returns>
+        public static uint Dec2Bcd(uint num) { return HornerScheme(num, 10, 0x10); }
+
+        private static uint HornerScheme(uint Num, uint Divider, uint Factor)
+        {
+            uint Remainder = 0, Quotient = 0, Result = 0;
+            Remainder = Num % Divider; Quotient = Num / Divider;
+
+            if (!(Quotient == 0 && Remainder == 0))
+                Result += HornerScheme(Quotient, Divider, Factor) * Factor + Remainder; return Result;
+        }
+    }
+}

--- a/src/CTrue.FsConnect/Bcd.cs
+++ b/src/CTrue.FsConnect/Bcd.cs
@@ -10,22 +10,36 @@
         /// </summary>
         /// <param name="num"></param>
         /// <returns></returns>
-        public static uint Bcd2Dec(uint num) { return HornerScheme(num, 0x10, 10); }
+        public static uint Bcd2Dec(uint num)
+        {
+            return HornerScheme(num, 0x10, 10);
+        }
 
         /// <summary>
         /// Converts from integer to binary coded decimal
         /// </summary>
         /// <param name="num"></param>
         /// <returns></returns>
-        public static uint Dec2Bcd(uint num) { return HornerScheme(num, 10, 0x10); }
+        public static uint Dec2Bcd(uint num)
+        {
+            return HornerScheme(num, 10, 0x10);
+        }
+
+        public static uint Dec2Bcd(double num)
+        {
+            return Dec2Bcd((uint) (num * 100));
+        }
 
         private static uint HornerScheme(uint Num, uint Divider, uint Factor)
         {
             uint Remainder = 0, Quotient = 0, Result = 0;
-            Remainder = Num % Divider; Quotient = Num / Divider;
+            Remainder = Num % Divider; 
+            Quotient = Num / Divider;
 
             if (!(Quotient == 0 && Remainder == 0))
-                Result += HornerScheme(Quotient, Divider, Factor) * Factor + Remainder; return Result;
+                Result += HornerScheme(Quotient, Divider, Factor) * Factor + Remainder; 
+            
+            return Result;
         }
     }
 }

--- a/src/CTrue.FsConnect/CTrue.FsConnect.csproj
+++ b/src/CTrue.FsConnect/CTrue.FsConnect.csproj
@@ -13,11 +13,11 @@ Contains SimConnect binaries, as distributed by the Flight Simulator 20202 SDK 0
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/c-true/FsConnect</RepositoryUrl>
     <PackageTags>msfs flight-simulator simconnect</PackageTags>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>Support for SimVar reflection, client event enum</PackageReleaseNotes>
-    <AssemblyVersion>1.3.1.0</AssemblyVersion>
-    <FileVersion>1.3.1.0</FileVersion>
+    <AssemblyVersion>1.3.2.0</AssemblyVersion>
+    <FileVersion>1.3.2.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/CTrue.FsConnect/CTrue.FsConnect.csproj
+++ b/src/CTrue.FsConnect/CTrue.FsConnect.csproj
@@ -15,7 +15,7 @@ Contains SimConnect binaries, as distributed by the Flight Simulator 20202 SDK 0
     <PackageTags>msfs flight-simulator simconnect</PackageTags>
     <Version>1.3.2</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>Support for SimVar reflection, client event enum</PackageReleaseNotes>
+    <PackageReleaseNotes>Added and updated some method signatures. * Added event ids for setting COM and NAV frequencies.</PackageReleaseNotes>
     <AssemblyVersion>1.3.2.0</AssemblyVersion>
     <FileVersion>1.3.2.0</FileVersion>
   </PropertyGroup>

--- a/src/CTrue.FsConnect/FrequencyBcd.cs
+++ b/src/CTrue.FsConnect/FrequencyBcd.cs
@@ -33,7 +33,14 @@ namespace CTrue.FsConnect
             _bcd32Value = BitConverter.ToUInt32(bytes, 0);
         }
 
-        public FrequencyBcd(uint bcd16Value)
+        public FrequencyBcd(uint bcd32Value)
+        {
+            _bcd32Value = bcd32Value;
+            var freqOutUint = Bcd.Bcd2Dec(_bcd32Value);
+            _value = (double)freqOutUint / 10000;
+        }
+
+        public FrequencyBcd(ushort bcd16Value)
         {
             _bcd16Value = bcd16Value;
             var freqOutUint = Bcd.Bcd2Dec(_bcd16Value);

--- a/src/CTrue.FsConnect/FrequencyBcd.cs
+++ b/src/CTrue.FsConnect/FrequencyBcd.cs
@@ -5,14 +5,20 @@ namespace CTrue.FsConnect
     public class FrequencyBcd
     {
         private double _value = 0;
-        private uint _bcdValue = 0;
+        private uint _bcd16Value = 0;
+        private uint _bcd32Value = 0;
 
         public double Value => _value;
 
         /// <summary>
-        /// Gets the BCD encoded
+        /// Gets the BCD encoded as 32 bit.
         /// </summary>
-        public uint BcdValue => _bcdValue;
+        public uint Bcd32Value => _bcd32Value;
+
+        /// <summary>
+        /// Gets the BCD encoded as 16 bit.
+        /// </summary>
+        public uint Bcd16Value => _bcd16Value;
 
         public FrequencyBcd(double freqValue)
         {
@@ -21,13 +27,16 @@ namespace CTrue.FsConnect
             uint encodable = (uint)((_value - 100) * 100);
             double remainder = ((_value * 100) - encodable) / 100.0;
 
-            _bcdValue = Bcd.Dec2Bcd(encodable);
+            _bcd16Value = Bcd.Dec2Bcd(encodable);
+
+            Byte[] bytes = BitConverter.GetBytes(Convert.ToInt32(freqValue * 1000000));
+            _bcd32Value = BitConverter.ToUInt32(bytes, 0);
         }
 
-        public FrequencyBcd(uint bcdValue)
+        public FrequencyBcd(uint bcd16Value)
         {
-            _bcdValue = bcdValue;
-            var freqOutUint = Bcd.Bcd2Dec(_bcdValue);
+            _bcd16Value = bcd16Value;
+            var freqOutUint = Bcd.Bcd2Dec(_bcd16Value);
             var tmp = freqOutUint + 10000;
             _value = (double)tmp / 100;
             //_value = Math.Round(_value * 4, MidpointRounding.ToEven) / 4;

--- a/src/CTrue.FsConnect/FrequencyBcd.cs
+++ b/src/CTrue.FsConnect/FrequencyBcd.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace CTrue.FsConnect
+{
+    public class FrequencyBcd
+    {
+        private double _value = 0;
+        private uint _bcdValue = 0;
+
+        public double Value => _value;
+
+        /// <summary>
+        /// Gets the BCD encoded
+        /// </summary>
+        public uint BcdValue => _bcdValue;
+
+        public FrequencyBcd(double freqValue)
+        {
+            _value = freqValue;
+
+            uint encodable = (uint)((_value - 100) * 100);
+            double remainder = ((_value * 100) - encodable) / 100.0;
+
+            _bcdValue = Bcd.Dec2Bcd(encodable);
+        }
+
+        public FrequencyBcd(uint bcdValue)
+        {
+            _bcdValue = bcdValue;
+            var freqOutUint = Bcd.Bcd2Dec(_bcdValue);
+            var tmp = freqOutUint + 10000;
+            _value = (double)tmp / 100;
+            //_value = Math.Round(_value * 4, MidpointRounding.ToEven) / 4;
+        }
+    }
+}

--- a/src/CTrue.FsConnect/FsConnect.cs
+++ b/src/CTrue.FsConnect/FsConnect.cs
@@ -342,6 +342,12 @@ namespace CTrue.FsConnect
         }
 
         /// <inheritdoc />
+        public void TransmitClientEvent(int eventId, uint dwData, int groupId)
+        {
+            _simConnect.TransmitClientEvent((uint)SIMCONNECT_SIMOBJECT_TYPE.USER, (FsConnectEnum)eventId, dwData, (FsConnectEnum)groupId, SIMCONNECT_EVENT_FLAG.DEFAULT);
+        }
+
+        /// <inheritdoc />
         public void SetText(string text, int duration)
         {
             _simConnect.Text(SIMCONNECT_TEXT_TYPE.PRINT_BLACK, duration, SimEvents.SetText, text);

--- a/src/CTrue.FsConnect/FsConnect.cs
+++ b/src/CTrue.FsConnect/FsConnect.cs
@@ -268,9 +268,9 @@ namespace CTrue.FsConnect
         }
 
         /// <inheritdoc />
-        public void RequestData(Enum requestId, int defineId, uint radius = 0, FsConnectSimobjectType type = FsConnectSimobjectType.User)
+        public void RequestData(int requestId, int defineId, uint radius = 0, FsConnectSimobjectType type = FsConnectSimobjectType.User)
         {
-            _simConnect?.RequestDataOnSimObjectType(requestId, (FsConnectEnum)defineId, radius, (SIMCONNECT_SIMOBJECT_TYPE)type);
+            _simConnect?.RequestDataOnSimObjectType((FsConnectEnum)requestId, (FsConnectEnum)defineId, radius, (SIMCONNECT_SIMOBJECT_TYPE)type);
         }
 
         #endregion

--- a/src/CTrue.FsConnect/FsEventNameId.cs
+++ b/src/CTrue.FsConnect/FsEventNameId.cs
@@ -3973,6 +3973,22 @@ namespace CTrue.FsConnect
         /// Set NAV2 Standby frequency.
         /// </summary>
         Nav2RadioSetHz,
+        /// <summary>
+        /// Set COM1 Standby frequency.
+        /// </summary>
+        ComStbyRadioSetHz,
+        /// <summary>
+        /// Set COM2 Standby frequency.
+        /// </summary>
+        Com2StbyRadioSetHz,
+        /// <summary>
+        /// Set NAV1 Standby frequency.
+        /// </summary>
+        Nav1StbyRadioSetHz,
+        /// <summary>
+        /// Set NAV2 Standby frequency.
+        /// </summary>
+        Nav2StbyRadioSetHz,
     };
     
     /// <summary>
@@ -4971,7 +4987,11 @@ namespace CTrue.FsConnect
             "COM_RADIO_SET_HZ",
             "COM2_RADIO_SET_HZ",
             "NAV1_RADIO_SET_HZ",
-            "NAV2_RADIO_SET_HZ"
+            "NAV2_RADIO_SET_HZ",
+            "COM_STBY_RADIO_SET_HZ",
+            "COM2_STBY_RADIO_SET_HZ",
+            "NAV1_STBY_RADIO_SET_HZ",
+            "NAV2_STBY_RADIO_SET_HZ"
         };
         
         /// <summary>

--- a/src/CTrue.FsConnect/FsEventNameId.cs
+++ b/src/CTrue.FsConnect/FsEventNameId.cs
@@ -4484,7 +4484,7 @@ namespace CTrue.FsConnect
             "AVIONICS_MASTER_SET",
             "TOGGLE_AVIONICS_MASTER",
             "COM_STBY_RADIO_SET",
-            "COM_STBY_RADIO_SWITCH_TO",
+            "COM_STBY_RADIO_SWAP",
             "COM_RADIO_FRACT_DEC_CARRY",
             "COM_RADIO_FRACT_INC_CARRY",
             "COM2_RADIO_WHOLE_DEC",

--- a/src/CTrue.FsConnect/FsEventNameId.cs
+++ b/src/CTrue.FsConnect/FsEventNameId.cs
@@ -3957,6 +3957,22 @@ namespace CTrue.FsConnect
         /// Show or hide multi-player race results.
         /// </summary>
         ToggleRaceresultsWindow,
+        /// <summary>
+        /// Set COM1 Standby frequency.
+        /// </summary>
+        ComRadioSetHz,
+        /// <summary>
+        /// Set COM2 Standby frequency.
+        /// </summary>
+        Com2RadioSetHz,
+        /// <summary>
+        /// Set NAV1 Standby frequency.
+        /// </summary>
+        Nav1RadioSetHz,
+        /// <summary>
+        /// Set NAV2 Standby frequency.
+        /// </summary>
+        Nav2RadioSetHz,
     };
     
     /// <summary>
@@ -4952,6 +4968,10 @@ namespace CTrue.FsConnect
             "MULTIPLAYER_VOICE_CAPTURE_STOP",
             "MULTIPLAYER_BROADCAST_VOICE_",
             "TOGGLE_RACERESULTS_WINDOW",
+            "COM_RADIO_SET_HZ",
+            "COM2_RADIO_SET_HZ",
+            "NAV1_RADIO_SET_HZ",
+            "NAV2_RADIO_SET_HZ"
         };
         
         /// <summary>

--- a/src/CTrue.FsConnect/FsSimVar.cs
+++ b/src/CTrue.FsConnect/FsSimVar.cs
@@ -298,7 +298,13 @@ namespace CTrue.FsConnect
 		AutopilotMaster,
 		AutopilotWingLeveler,
 		AutopilotNav1Lock,
+		/// <summary>
+		/// Heading mode active
+		/// </summary>
 		AutopilotHeadingLock,
+		/// <summary>
+		/// Selected heading
+		/// </summary>
 		AutopilotHeadingLockDir,
 		AutopilotAltitudeLock,
 		AutopilotAltitudeLockVar,

--- a/src/CTrue.FsConnect/IFsConnect.cs
+++ b/src/CTrue.FsConnect/IFsConnect.cs
@@ -236,7 +236,7 @@ namespace CTrue.FsConnect
         /// <param name="defineId">The definition id to associated with the data definition.</param>
         /// <param name="radius">Radius in meters. Should be less that 2000000 (200km).</param>
         /// <param name="type"></param>
-        void RequestData(Enum requestId, int defineId, uint radius = 0, FsConnectSimobjectType type = FsConnectSimobjectType.User);
+        void RequestData(int requestId, int defineId, uint radius = 0, FsConnectSimobjectType type = FsConnectSimobjectType.User);
 
         /// <summary>
         /// Updates a sim object in the flight simulator.

--- a/src/CTrue.FsConnect/IFsConnect.cs
+++ b/src/CTrue.FsConnect/IFsConnect.cs
@@ -277,6 +277,14 @@ namespace CTrue.FsConnect
         void TransmitClientEvent(Enum eventId, uint dwData, Enum groupId);
 
         /// <summary>
+        /// Sends a client event to flight simulator.
+        /// </summary>
+        /// <param name="eventId"></param>
+        /// <param name="dwData"></param>
+        /// <param name="groupId"></param>
+        void TransmitClientEvent(int eventId, uint dwData, int groupId);
+
+        /// <summary>
         /// Maps a client event to a sim event.
         /// </summary>
         /// <param name="groupId"></param>

--- a/src/CTrue.FsConnect/SimVarReflector.cs
+++ b/src/CTrue.FsConnect/SimVarReflector.cs
@@ -110,6 +110,7 @@ namespace CTrue.FsConnect
 
         private SIMCONNECT_DATATYPE GetDataType(FieldInfo field, SimVarAttribute attr)
         {
+            // Always return the specified data type if provided
             if (attr != null && attr.DataType != SIMCONNECT_DATATYPE.INVALID)
             {
                 return attr.DataType;
@@ -147,6 +148,12 @@ namespace CTrue.FsConnect
 
             if (field.FieldType == typeof(bool))
                 return SIMCONNECT_DATATYPE.INT32;
+
+            if (field.FieldType == typeof(uint) || field.FieldType == typeof(int))
+                return SIMCONNECT_DATATYPE.INT32;
+
+            if (field.FieldType == typeof(ulong) || field.FieldType == typeof(long))
+                return SIMCONNECT_DATATYPE.INT64;
 
             // Default data type
             return SIMCONNECT_DATATYPE.FLOAT64;


### PR DESCRIPTION
- Issue #15 fixed by adding support for setting COM frequencies, including 3 decimals, through the RadioManager.
- Added event ids for frequencies
- Updated and added some method signatures
- Integration tests for RadioManager
- Simple utility class for BCD handling.